### PR TITLE
Refactor datecalc parser and add operator precedence

### DIFF
--- a/datecalc/index.md
+++ b/datecalc/index.md
@@ -12,41 +12,45 @@ tags:
 
 ## Syntax
 
-The calculator supports adding and subtracting _date_ and _delta_ objects.
-
-Dates must be in `MM/DD/YYYY` format.
-
-Deltas must be in `<number> <unit>` format where `<number>` is a whole number
-and `<unit>` is one of: `second`, `minute`, `hour`, `day`, `week`, `month`, or
-`year`. For example, `24 hours`, `1 week`, or `30 years`.
-
-Deltas may be converted to another time unit by ending the expression in
-`as <unit>`. For example, `1 week as days` returns `7 days`.
-
-The output will be either a _date_ or _delta_ depending on the context.
-
-## Grammar
+Date calculator syntax in BNF grammar format.
 
 ```js
-<dateExpr>    ::= <dateOrDelta> <castExpr>? (<op> <dateExpr>)?
+<program> ::= (<dateExpr> | <durationExpr> <castExpr>*)
 
-<castExpr>    ::= ("as" | "to") <unit>
+<dateExpr> ::= <date>
+    | <date> (<plus> | <minus>) <durationExpr>
 
-<dateOrDelta> ::= <date> | <delta>
+<durationExpr> ::= <duration>
+    | <duration> (<plus> | <minus>) <durationExpr>
+    | <date> <minus> <dateExpr>
 
-<date>        ::= ("now" | "today" | <number> "/" <number> "/" <number>)
+<date> ::= ("now" | "today" | <number> "/" <number> "/" <number>)
 
-<delta>       ::= <number> <unit>
+<duration> ::= <number> <optWs> <unit>
 
-<op>          ::= ("+" | "-")
+<castExpr> ::= <ws> ("as" | "to") <ws> <unit>
 
-<number>      ::= [0-9]+
+<unit> ::= ("millisecond" | "second" | "minute" | "hour"
+    | "day" | "week" | "month" | "year")
 
-<unit>        ::= ("millisecond" | "second" | "minute" | "hour"
-                    | "day" | "week" | "month" | "year")
+<number> ::= [0-9]+
+<plus> ::= <optWs> "+" <optWs>
+<minus> ::= <optWs> "-" <optWs>
+
+<ws> ::= " "+
+<optWs> ::= " "*
 ```
 
 ## Updates
+
+### 1/25/2024
+
+-   Added operator precedence
+-   Improved error messages
+
+### 12/27/2023
+
+-   Improved grammar and refactored parser
 
 ### 10/19/2023
 

--- a/datecalc/src/components.tsx
+++ b/datecalc/src/components.tsx
@@ -1,11 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { tokenize, parse, resolve, formatTokens, formatAst } from "./datecalc";
-
-const dateFmt: Intl.DateTimeFormatOptions = {
-    dateStyle: "full",
-    timeStyle: "short",
-    hourCycle: "h23",
-};
+import { tokenize, parse, evaluate, formatTokens, formatProgram } from "./datecalc";
 
 interface DateCalcFormProps {
     initial: string;
@@ -21,22 +15,28 @@ export const DateCalcForm: React.FC<DateCalcFormProps> = ({ initial }) => {
         setState(value);
     };
 
-    let tokens, ast, result, output, err;
+    let tokens, programNode, output, err;
     let formattedTokens = "";
-    let formattedAst = "";
+    let formattedProgram = "";
 
     try {
         if (state) {
             tokens = tokenize(state);
-            ast = parse(tokens);
-            result = resolve(ast);
-            output = result instanceof Date ? result.toLocaleString("en-US", dateFmt) : result.toString();
-            formattedTokens = formatTokens(tokens);
-            formattedAst = formatAst(ast);
+            console.log(tokens);
+            programNode = parse(tokens);
+            console.log(programNode);
+            output = evaluate(programNode);
         }
     } catch (ex) {
         console.log(ex);
         err = ex.toString();
+    }
+
+    if (tokens) {
+        formattedTokens = formatTokens(tokens);
+    }
+    if (programNode) {
+        formattedProgram = formatProgram(programNode);
     }
 
     return (
@@ -45,7 +45,7 @@ export const DateCalcForm: React.FC<DateCalcFormProps> = ({ initial }) => {
                 <p className="label">Input:</p>
                 <input type="text" autoComplete="off" value={state || ""} onChange={onChange} />
                 <p className="label">Output:</p>
-                <p className={"output" + ((err && " error") || "")}>{err || output || "(none)"}</p>
+                <p className={"output" + ((err && " error") || "")}>{err || output || ""}</p>
             </div>
             <h2 id="examples">Examples</h2>
             <ul>
@@ -67,7 +67,7 @@ export const DateCalcForm: React.FC<DateCalcFormProps> = ({ initial }) => {
                 </div>
                 <div className="col">
                     <span className="label">AST:</span>
-                    <pre>{formattedAst || "(none)"}</pre>
+                    <pre>{formattedProgram || "(none)"}</pre>
                 </div>
             </div>
         </>

--- a/datecalc/src/index.tsx
+++ b/datecalc/src/index.tsx
@@ -2,8 +2,14 @@ import { DateCalcForm } from "./components";
 import React from "react";
 import ReactDOM from "react-dom";
 
+const today = new Date().toLocaleDateString("en-US", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+});
+
 const el = document.getElementById("dateCalcForm");
-const reactEl = <DateCalcForm initial="12/25/2021 + 7 days" />;
+const reactEl = <DateCalcForm initial={`${today} + 7 days`} />;
 
 // if (process.env.NODE_ENV === "production") {
 //     ReactDOM.hydrate(reactEl, el);


### PR DESCRIPTION
Simplify grammar, remove useless code from parser, improve error messages, and add operator precedence.